### PR TITLE
Patch unit test crash mssg

### DIFF
--- a/config.py
+++ b/config.py
@@ -33,6 +33,7 @@ DEFAULT_STDOUT_VISIBILITY = VISIBLE
 
 # output
 TIMEOUT_MSSG = 'Timeout during test execution, check for an infinite loop\n'
+CRASH_MSSG = '\nTest execution ended with abnormal return code, check for crashes\n'
 OCTOTHORPE_LINE = '#'*27
 OCTOTHORPE_WALL = '#'+' '*25+'#'
 INFO_UNSUPPORTED_TEST = '[INFO] Unsupported Test'

--- a/support/c++/test_running.py
+++ b/support/c++/test_running.py
@@ -36,6 +36,8 @@ def run_performance_test(timeout: float) -> Tuple[bool,str]:
     except Exception as e:
         output = str(e)
     ret = p.returncode
+    if ret != 0:
+        output += '\nTest execution ended with abnormal return code, check for crashes\n'
     return ret == 0, output
 
 def remove_end_of_line_whitespace(s: str) -> str:

--- a/support/c++/test_running.py
+++ b/support/c++/test_running.py
@@ -21,6 +21,8 @@ def run_unit_test(timeout: float) -> Tuple[bool,str]:
     except Exception as e:
         output = str(e)
     ret = p.returncode
+    if ret != 0:
+        output += '\nTest execution ended with abnormal return code, check for crashes\n'
     return ret == 0, output
 
 def run_performance_test(timeout: float) -> Tuple[bool,str]:

--- a/support/c++/test_running.py
+++ b/support/c++/test_running.py
@@ -32,7 +32,7 @@ def run_performance_test(timeout: float) -> Tuple[bool,str]:
         output_en, _ = p.communicate(timeout=timeout) #p.stdout.decode('utf-8')
         output = output_en.decode('utf-8')
     except subprocess.TimeoutExpired as e:
-        output = "Timeout during test execution, check for an infinite loop\n"
+        output = TIMEOUT_MSSG
     except Exception as e:
         output = str(e)
     ret = p.returncode

--- a/support/c++/test_running.py
+++ b/support/c++/test_running.py
@@ -14,7 +14,7 @@ def run_unit_test(timeout: float) -> Tuple[bool,str]:
     run_cmd = ["./unit_test", "2>&1"]
     p = subprocess.Popen(run_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     try:
-        output_en, err_en = p.communicate(timeout=timeout) #p.stdout.decode('utf-8')
+        output_en, _ = p.communicate(timeout=timeout) #p.stdout.decode('utf-8')
         output = output_en.decode('utf-8')
     except subprocess.TimeoutExpired as e:
         output = TIMEOUT_MSSG
@@ -27,7 +27,7 @@ def run_performance_test(timeout: float) -> Tuple[bool,str]:
     run_cmd = ["./performance_test", "2>&1"]
     p = subprocess.Popen(run_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     try:
-        output_en, err_en = p.communicate(timeout=timeout) #p.stdout.decode('utf-8')
+        output_en, _ = p.communicate(timeout=timeout) #p.stdout.decode('utf-8')
         output = output_en.decode('utf-8')
     except subprocess.TimeoutExpired as e:
         output = "Timeout during test execution, check for an infinite loop\n"

--- a/support/c++/test_running.py
+++ b/support/c++/test_running.py
@@ -5,7 +5,7 @@ from time import time
 from typing import Tuple
 from attributes import Attributes
 
-from config import TIMEOUT_MSSG
+from config import TIMEOUT_MSSG, CRASH_MSSG
 from results import PartialTestResult
 from test_types import UnsupportedTestException
 
@@ -22,7 +22,7 @@ def run_unit_test(timeout: float) -> Tuple[bool,str]:
         output = str(e)
     ret = p.returncode
     if ret != 0:
-        output += '\nTest execution ended with abnormal return code, check for crashes\n'
+        output += CRASH_MSSG
     return ret == 0, output
 
 def run_performance_test(timeout: float) -> Tuple[bool,str]:
@@ -37,7 +37,7 @@ def run_performance_test(timeout: float) -> Tuple[bool,str]:
         output = str(e)
     ret = p.returncode
     if ret != 0:
-        output += '\nTest execution ended with abnormal return code, check for crashes\n'
+        output += CRASH_MSSG
     return ret == 0, output
 
 def remove_end_of_line_whitespace(s: str) -> str:

--- a/support/java/test_running.py
+++ b/support/java/test_running.py
@@ -5,7 +5,7 @@ from time import time
 from typing import Tuple
 from attributes import Attributes
 
-from config import JAVA_CLASSPATH, TIMEOUT_MSSG
+from config import JAVA_CLASSPATH, TIMEOUT_MSSG, CRASH_MSSG
 from results import PartialTestResult
 from test_types import UnsupportedTestException
 
@@ -31,7 +31,7 @@ def run_code(class_name: str, timeout: float) -> Tuple[bool,str]:
         output = str(e)
     ret = p.returncode
     if ret != 0:
-        output += '\nTest execution ended with abnormal return code, check for crashes\n'
+        output += CRASH_MSSG
     return ret == 0, output
 
 def run_unit_test(timeout: float) -> Tuple[bool,str]:

--- a/support/java/test_running.py
+++ b/support/java/test_running.py
@@ -30,6 +30,8 @@ def run_code(class_name: str, timeout: float) -> Tuple[bool,str]:
     except Exception as e:
         output = str(e)
     ret = p.returncode
+    if ret != 0:
+        output += '\nTest execution ended with abnormal return code, check for crashes\n'
     return ret == 0, output
 
 def run_unit_test(timeout: float) -> Tuple[bool,str]:

--- a/support/python/test_running.py
+++ b/support/python/test_running.py
@@ -5,7 +5,7 @@ from time import time
 from typing import Tuple
 from attributes import Attributes
 
-from config import JAVA_CLASSPATH, TIMEOUT_MSSG
+from config import TIMEOUT_MSSG, CRASH_MSSG
 from results import PartialTestResult
 from test_types import UnsupportedTestException
 
@@ -31,7 +31,7 @@ def run_code(class_name: str, timeout: float) -> Tuple[bool,str]:
         output = str(e)
     ret = p.returncode
     if ret != 0:
-        output += '\nTest execution ended with abnormal return code, check for crashes\n'
+        output += CRASH_MSSG
     return ret == 0, output
 
 def run_unit_test(timeout: float) -> Tuple[bool,str]:

--- a/support/python/test_running.py
+++ b/support/python/test_running.py
@@ -30,6 +30,8 @@ def run_code(class_name: str, timeout: float) -> Tuple[bool,str]:
     except Exception as e:
         output = str(e)
     ret = p.returncode
+    if ret != 0:
+        output += '\nTest execution ended with abnormal return code, check for crashes\n'
     return ret == 0, output
 
 def run_unit_test(timeout: float) -> Tuple[bool,str]:


### PR DESCRIPTION
* Added a line to the output when the return code from a test is non-zero to indicate that the test exited abnormally and to look for crashes
* Replaces string constants with references to a constant defined in `config.py`.
* Renamed unused `error_en` to `_` in `support/c++/test_running.py`
* Removed a reference to JAVA_CLASSPATH in `support/python/test_running.py`